### PR TITLE
Fix 3rdparty detector bugs

### DIFF
--- a/nab/labeler.py
+++ b/nab/labeler.py
@@ -106,7 +106,7 @@ class CorpusLabel(object):
   benchmark corpus.
   """
 
-  def __init__(self, path, corpus):
+  def __init__(self, path, corpus, remove_duplicates=False):
     """
     Initializes a CorpusLabel object by getting the anomaly windows and labels.
     When this is done for combining raw user labels, we skip getLabels()
@@ -114,6 +114,7 @@ class CorpusLabel(object):
 
     @param path    (string)      Name of file containing the set of labels.
     @param corpus  (nab.Corpus)  Corpus object.
+    @param remove_duplicates (bool) Whether to remove duplicate rows in the label data
     """
     self.path = path
 
@@ -125,7 +126,7 @@ class CorpusLabel(object):
 
     if "raw" not in self.path:
       # Do not get labels from files in the path nab/labels/raw
-      self.getLabels()
+      self.getLabels(remove_duplicates)
 
 
   def getWindows(self):
@@ -192,7 +193,7 @@ class CorpusLabel(object):
           raise ValueError("In the label file %s, windows overlap." % self.path)
 
 
-  def getLabels(self):
+  def getLabels(self, remove_duplicates=False):
     """
     Get Labels as a dictionary of key-value pairs of a relative path and its
     corresponding binary vector of anomaly labels. Labels are simply a more
@@ -214,7 +215,8 @@ class CorpusLabel(object):
           labels["label"].values[indices.values] = 1
 
         # remove duplicate rows (somehow they snuck in for certain datasets)
-        labels = labels.drop_duplicates(subset=['timestamp'])
+        if remove_duplicates:
+            labels = labels.drop_duplicates(subset=['timestamp'])
 
         self.labels[relativePath] = labels
 

--- a/nab/labeler.py
+++ b/nab/labeler.py
@@ -213,6 +213,9 @@ class CorpusLabel(object):
           indices = betweenT1AndT2.loc[:,"label"].index
           labels["label"].values[indices.values] = 1
 
+        # remove duplicate rows (somehow they snuck in for certain datasets)
+        labels = labels.drop_duplicates(subset=['timestamp'])
+
         self.labels[relativePath] = labels
 
       else:

--- a/nab/runner.py
+++ b/nab/runner.py
@@ -87,10 +87,10 @@ class Runner(object):
     self.profiles = None
 
 
-  def initialize(self):
+  def initialize(self, remove_duplicate_labels=False):
     """Initialize all the relevant objects for the run."""
     self.corpus = Corpus(self.dataDir)
-    self.corpusLabel = CorpusLabel(path=self.labelPath, corpus=self.corpus)
+    self.corpusLabel = CorpusLabel(path=self.labelPath, corpus=self.corpus, remove_duplicates=remove_duplicate_labels)
 
     with open(self.profilesPath) as p:
       self.profiles = json.load(p)

--- a/nab/sweeper.py
+++ b/nab/sweeper.py
@@ -301,6 +301,7 @@ class Sweeper(object):
       scores      (list) List of per-row scores, to be saved in score file
       matchingRow (ThresholdScore)
     """
+    threshold = float(threshold)
     anomalyList = self.calcSweepScore(
       timestamps, anomalyScores, windowLimits, dataSetName)
     scoresByThreshold = self.calcScoreByThreshold(anomalyList)
@@ -308,10 +309,10 @@ class Sweeper(object):
     matchingRow = None
     prevRow = None
     for thresholdScore in scoresByThreshold:
-      if thresholdScore.threshold == threshold:
+      if float(thresholdScore.threshold) == threshold:
         matchingRow = thresholdScore
         break
-      elif thresholdScore.threshold < threshold:
+      elif float(thresholdScore.threshold) < threshold:
         matchingRow = prevRow
         break
 

--- a/run.py
+++ b/run.py
@@ -89,7 +89,7 @@ def main(args):
                   thresholdPath=thresholdsFile,
                   numCPUs=numCPUs)
 
-  runner.initialize()
+  runner.initialize(args.removeDuplicateLabels)
 
   if args.detect:
     detectorConstructors = getDetectorClassConstructors(args.detectors)
@@ -139,6 +139,11 @@ if __name__ == "__main__":
 
   parser.add_argument("--skipConfirmation",
                     help="If specified will skip the user confirmation step",
+                    default=False,
+                    action="store_true")
+
+  parser.add_argument("--removeDuplicateLabels",
+                    help="If specified will remove any duplicate rows from the labeled NAB data",
                     default=False,
                     action="store_true")
 


### PR DESCRIPTION
I noticed when evaluating my own detector using [this process](https://github.com/numenta/NAB/wiki/Twitter-Anomaly-Detector) that there were two bugs that got in the way:

1. The default NAB labels contained duplicate rows, but the output of my detector did not contain duplicates. This resulted in a length difference between the labels and the anomaly scores, which raised an AssertionError. I fixed this by adding an optional `--removeDuplicateLabels` flag. The default behavior remains unchanged.
2. The anomaly scores from my output csv were being read in as strings instead of floats. I forced casting to float in `sweeper.py`, which does not affect the default behavior because the anomaly scores from the default detectors are correctly read in as floats anyway.